### PR TITLE
Fix: Resolve linting issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,11 @@ func main() {
 		fmt.Println("Error connecting:", err)
 		os.Exit(1)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+		}
+	}()
 
 	PrintConnectionState(conn)
 }

--- a/tls_util.go
+++ b/tls_util.go
@@ -85,7 +85,7 @@ func ConnectTLS(cfg *Config, tlsConfig *tls.Config) (*tls.Conn, error) {
 	tlsConn := tls.Client(conn, tlsConfig)
 	err = tlsConn.Handshake()
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("TLS Handshake failed: %w", err)
 	}
 


### PR DESCRIPTION
Resolves two `errcheck` linting errors by handling the return value of `conn.Close()`.

- In `main.go`, the deferred `conn.Close()` is wrapped in a function to log any potential error to stderr.
- In `tls_util.go`, the error from `conn.Close()` is explicitly ignored as it occurs within an error handling block where the original error is more significant.

Also ran `go fmt`, `go vet`, and `golangci-lint` to ensure code quality.